### PR TITLE
Cut 1.1.0 release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    record_tag_helper (1.0.0)
+    record_tag_helper (1.1.0)
       actionview (>= 5)
 
 GEM

--- a/lib/record_tag_helper/version.rb
+++ b/lib/record_tag_helper/version.rb
@@ -1,3 +1,3 @@
 module RecordTagHelper
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.1.0'.freeze
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,14 +14,6 @@ silence_warnings do
 end
 
 module RenderERBUtils
-  def view
-    @view ||= begin
-      path = ActionView::FileSystemResolver.new(FIXTURE_LOAD_PATH)
-      view_paths = ActionView::PathSet.new([path])
-      ActionView::Base.new(view_paths)
-    end
-  end
-
   def render_erb(string)
     @virtual_path = nil
 
@@ -29,9 +21,8 @@ module RenderERBUtils
       string.strip,
       "test template",
       ActionView::Template::Handlers::ERB,
-      {}
+      {format: :html, locals: []}
     )
-
-    template.render(self, {}).strip
+    self.render(template: template)
   end
 end


### PR DESCRIPTION
A new release is needed to allow compatibility with Rails 6. The actual changes were merged in https://github.com/rails/record_tag_helper/pull/10 but no new release has been made since then. 
